### PR TITLE
test: trigger auto-branching (size check)

### DIFF
--- a/supabase/migrations/20260618111756_autobranch_size_test.sql
+++ b/supabase/migrations/20260618111756_autobranch_size_test.sql
@@ -1,0 +1,2 @@
+-- no-op migration to trigger Supabase auto-branching (compute-size test)
+DO $$ BEGIN RAISE NOTICE 'auto-branching size test'; END $$;


### PR DESCRIPTION
Throwaway PR — adds a no-op migration to trigger Supabase auto-branching so we can inspect the preview branch's compute size. Will close without merging.