### PR TITLE
ci: WARP IPv6 direct-connection test (throwaway)

### DIFF
--- a/.github/workflows/sb-warp-ipv6.yml
+++ b/.github/workflows/sb-warp-ipv6.yml
@@ -25,7 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: supabase/setup-cli@v2
-        with: { version: latest, github-token: ${{ github.token }} }
+        with:
+          version: latest
+          github-token: ${{ github.token }}
 
       - name: Baseline - no IPv6 before WARP
         run: |
@@ -78,5 +80,7 @@ jobs:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
     steps:
       - uses: supabase/setup-cli@v2
-        with: { version: latest, github-token: ${{ github.token }} }
+        with:
+          version: latest
+          github-token: ${{ github.token }}
       - run: supabase branches delete "ci-warp-test-${{ github.event.pull_request.number }}" --project-ref "dewddkcmwrzbpynylyhg" --yes || true

--- a/.github/workflows/sb-warp-ipv6.yml
+++ b/.github/workflows/sb-warp-ipv6.yml
@@ -1,0 +1,82 @@
+name: sb-warp-ipv6
+
+# SAFETY: only touches a uniquely-named PREVIEW branch; never production; always
+# deletes (if: always() + closed job). Proves WARP gives the runner IPv6 egress
+# so the DIRECT (IPv6-only) branch connection works without the pooler.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: read
+concurrency:
+  group: sb-warp-${{ github.event.pull_request.number }}
+
+env:
+  SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+  PROJECT_ID: dewddkcmwrzbpynylyhg
+  BRANCH_NAME: ci-warp-test-${{ github.event.pull_request.number }}
+
+jobs:
+  warp:
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v2
+        with: { version: latest, github-token: ${{ github.token }} }
+
+      - name: Baseline - no IPv6 before WARP
+        run: |
+          echo "IPv6 egress before WARP: $(curl -s6 --max-time 8 https://api6.ip.sb || echo 'NONE (expected on GH runner)')"
+
+      - name: Install + connect Cloudflare WARP (IPv6 via WARP, IPv4 stays direct)
+        run: |
+          set -euo pipefail
+          curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflare-client.list
+          sudo apt-get update -qq && sudo apt-get install -y -qq cloudflare-warp
+          sudo warp-cli --accept-tos registration new
+          sudo warp-cli --accept-tos mode warp
+          # keep IPv4 OUT of the tunnel so the runner's IPv4 link to GitHub is untouched
+          sudo warp-cli --accept-tos tunnel ip add-range 0.0.0.0/0 || echo "split-tunnel set failed; falling back to full tunnel"
+          sudo warp-cli --accept-tos connect
+          for i in $(seq 1 20); do
+            curl -s6 --max-time 5 https://api6.ip.sb >/dev/null && break || sleep 2
+          done
+          V6=$(curl -s6 --max-time 8 https://api6.ip.sb || echo FAILED)
+          echo "IPv6 egress after WARP: $V6"
+          [ "$V6" != FAILED ] || { echo "WARP did not provide IPv6"; exit 1; }
+
+      - name: Create Small branch
+        run: supabase branches create "$BRANCH_NAME" --project-ref "$PROJECT_ID" --size small --yes
+
+      - name: db push over the DIRECT IPv6 connection (failed without WARP)
+        run: |
+          set -euo pipefail
+          supabase branches get "$BRANCH_NAME" --project-ref "$PROJECT_ID" -o env > creds.env
+          DIRECT=$(grep '^POSTGRES_URL_NON_POOLING=' creds.env | cut -d= -f2- | tr -d '"')
+          echo "::add-mask::$DIRECT"
+          echo "direct host: $(echo "$DIRECT" | grep -oP 'db\.[a-z0-9]+\.supabase\.co')"
+          psql "$DIRECT" -tAc "select 'connected over direct IPv6'" | head -1
+          supabase db push --db-url "$DIRECT" --include-all --yes
+          for t in pastes slugs; do
+            OK=$(psql "$DIRECT" -tAc "select to_regclass('public.$t') is not null")
+            echo "public.$t present: $OK"; [ "$OK" = t ] || { echo "FAIL"; exit 1; }
+          done
+          echo "PASS: direct IPv6 connection worked via WARP"
+
+      - name: Always delete branch
+        if: always()
+        run: supabase branches delete "$BRANCH_NAME" --project-ref "$PROJECT_ID" --yes || true
+
+  cleanup-on-close:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+    steps:
+      - uses: supabase/setup-cli@v2
+        with: { version: latest, github-token: ${{ github.token }} }
+      - run: supabase branches delete "ci-warp-test-${{ github.event.pull_request.number }}" --project-ref "dewddkcmwrzbpynylyhg" --yes || true

--- a/.github/workflows/sb-warp-ipv6.yml
+++ b/.github/workflows/sb-warp-ipv6.yml
@@ -44,12 +44,29 @@ jobs:
           # keep IPv4 OUT of the tunnel so the runner's IPv4 link to GitHub is untouched
           sudo warp-cli --accept-tos tunnel ip add-range 0.0.0.0/0 || echo "split-tunnel set failed; falling back to full tunnel"
           sudo warp-cli --accept-tos connect
-          for i in $(seq 1 20); do
-            curl -s6 --max-time 5 https://api6.ip.sb >/dev/null && break || sleep 2
+          # connect is async - gate on the daemon actually reporting Connected
+          for i in $(seq 1 30); do
+            ST=$(sudo warp-cli --accept-tos status 2>/dev/null || true)
+            echo "[poll $i] $ST"
+            echo "$ST" | grep -qi "Connected" && break
+            sleep 2
           done
-          V6=$(curl -s6 --max-time 8 https://api6.ip.sb || echo FAILED)
-          echo "IPv6 egress after WARP: $V6"
-          [ "$V6" != FAILED ] || { echo "WARP did not provide IPv6"; exit 1; }
+          echo "=== warp-cli status ==="; sudo warp-cli --accept-tos status || true
+          echo "=== warp-cli settings (tail) ==="; sudo warp-cli --accept-tos settings 2>/dev/null | tail -25 || true
+          echo "=== ip -6 addr ==="; ip -6 addr || true
+          echo "=== ip -6 route ==="; ip -6 route || true
+          # IPv6 egress to Cloudflare anycast - no DNS dependency
+          echo "=== Cloudflare anycast over IPv6 (no DNS) ==="
+          curl -6 --max-time 10 "https://[2606:4700:4700::1111]/cdn-cgi/trace" || echo "cf-anycast-v6 FAILED"
+          # IPv6 egress to a NON-Cloudflare public host (the real test)
+          V6=FAILED
+          for i in $(seq 1 5); do
+            V6=$(curl -s6 --max-time 10 https://api6.ipify.org || curl -s6 --max-time 10 https://api6.ip.sb || echo FAILED)
+            [ "$V6" != FAILED ] && [ -n "$V6" ] && break
+            sleep 3
+          done
+          echo "IPv6 egress (public, non-CF) after WARP: $V6"
+          [ "$V6" != FAILED ] && [ -n "$V6" ] || { echo "WARP did not provide working IPv6 egress"; exit 1; }
 
       - name: Create Small branch
         run: supabase branches create "$BRANCH_NAME" --project-ref "$PROJECT_ID" --size small --yes


### PR DESCRIPTION
Throwaway. Workflow-only change. Tests that Cloudflare WARP gives the runner IPv6 egress so the DIRECT (IPv6-only) branch connection works for db push, as an alternative to the session pooler. Closes without merge.