### PR TITLE
CF + Supabase integration harness + per-PR preview branching

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -1,0 +1,34 @@
+name: Preview teardown
+
+# Deletes the per-PR Supabase preview branch when the PR is closed (merged or
+# not). Pairs with preview.yml, which provisions it. Idempotent - no-op if the
+# branch is already gone.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete the Supabase preview branch
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
+          GIT_BRANCH: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          API="https://api.supabase.com/v1"
+          BID="$(curl -fsSL -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+            "$API/projects/$PROJECT_REF/branches" \
+            | jq -r --arg b "$GIT_BRANCH" '.[]|select(.git_branch==$b)|.id')"
+          if [ -n "$BID" ]; then
+            echo "deleting preview branch $BID for $GIT_BRANCH"
+            curl -fsSL -X DELETE -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" "$API/branches/$BID"
+          else
+            echo "no preview branch for $GIT_BRANCH - nothing to delete"
+          fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,22 +46,35 @@ jobs:
           PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
           GIT_BRANCH: ${{ github.head_ref }}
         run: |
-          # The Supabase GitHub integration creates the branch on PR open; it
-          # may still be provisioning, so poll until ACTIVE_HEALTHY.
+          # The Supabase GitHub integration creates the branch on PR open.
+          # Resolve it by ID from `branches list` (name-based `branches get`
+          # is version-fragile and returned empty in CI), poll until the
+          # branch reaches a healthy status, then read its connection creds.
+          BID=""
           for i in $(seq 1 40); do
-            JSON=$(supabase branches get "$GIT_BRANCH" --project-ref "$PROJECT_REF" --output json 2>/dev/null || true)
-            STATUS=$(echo "$JSON" | jq -r '.status // empty')
-            if [ -n "$JSON" ] && [ "$JSON" != "null" ] && echo "$JSON" | jq -e '.SUPABASE_URL' >/dev/null 2>&1; then
-              echo "url=$(echo "$JSON" | jq -r '.SUPABASE_URL')" >> "$GITHUB_OUTPUT"
-              echo "key=$(echo "$JSON" | jq -r '.SUPABASE_SERVICE_ROLE_KEY')" >> "$GITHUB_OUTPUT"
-              echo "resolved branch after ${i} poll(s)"
-              exit 0
-            fi
-            echo "waiting for preview branch (${i}) status=${STATUS:-none}"
-            sleep 15
+            LIST=$(supabase branches list --project-ref "$PROJECT_REF" --output json 2>/dev/null || echo '[]')
+            ROW=$(echo "$LIST" | jq -c --arg b "$GIT_BRANCH" '.[]|select(.git_branch==$b)' 2>/dev/null)
+            BID=$(echo "$ROW" | jq -r '.id // empty')
+            STATUS=$(echo "$ROW" | jq -r '.status // empty')
+            case "$STATUS" in
+              ACTIVE_HEALTHY|MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED)
+                echo "branch $BID healthy ($STATUS) after ${i} poll(s)"
+                break ;;
+              MIGRATIONS_FAILED|FUNCTIONS_FAILED)
+                echo "::error::preview branch $BID failed provisioning: $STATUS"
+                exit 1 ;;
+              *)
+                echo "waiting for preview branch (${i}) status=${STATUS:-not-created-yet}"
+                BID=""; sleep 15 ;;
+            esac
           done
-          echo "::error::preview branch never became available for $GIT_BRANCH"
-          exit 1
+          if [ -z "$BID" ]; then
+            echo "::error::preview branch never became healthy for $GIT_BRANCH"
+            exit 1
+          fi
+          JSON=$(supabase branches get "$BID" --output json)
+          echo "url=$(echo "$JSON" | jq -r '.SUPABASE_URL')" >> "$GITHUB_OUTPUT"
+          echo "key=$(echo "$JSON" | jq -r '.SUPABASE_SERVICE_ROLE_KEY')" >> "$GITHUB_OUTPUT"
 
       - name: Install deps (root + astro)
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,85 @@
+name: Preview (PR branch)
+
+# Per-PR preview: Supabase's GitHub integration auto-creates a preview BRANCH
+# database from the PR (isolated Postgres, its own ref + keys). Cloudflare has
+# no equivalent auto-wiring, so this workflow reads the branch's connection
+# details and uploads a Worker *preview version* bound to that branch DB -
+# without touching the deployed paste.erfi.io.
+#
+# Requires repo secrets: SUPABASE_ACCESS_TOKEN, CLOUDFLARE_API_TOKEN,
+# CLOUDFLARE_ACCOUNT_ID; and repo variable SUPABASE_PROJECT_REF.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: preview-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Reuse the secret-free gate (typecheck, lint, tests, build) before deploying.
+  gate:
+    uses: ./.github/workflows/ci.yml
+
+  preview:
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Resolve the auto-created Supabase preview branch
+        id: branch
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
+          GIT_BRANCH: ${{ github.head_ref }}
+        run: |
+          # The Supabase GitHub integration creates the branch on PR open; it
+          # may still be provisioning, so poll until ACTIVE_HEALTHY.
+          for i in $(seq 1 40); do
+            JSON=$(supabase branches get "$GIT_BRANCH" --project-ref "$PROJECT_REF" --output json 2>/dev/null || true)
+            STATUS=$(echo "$JSON" | jq -r '.status // empty')
+            if [ -n "$JSON" ] && [ "$JSON" != "null" ] && echo "$JSON" | jq -e '.SUPABASE_URL' >/dev/null 2>&1; then
+              echo "url=$(echo "$JSON" | jq -r '.SUPABASE_URL')" >> "$GITHUB_OUTPUT"
+              echo "key=$(echo "$JSON" | jq -r '.SUPABASE_SERVICE_ROLE_KEY')" >> "$GITHUB_OUTPUT"
+              echo "resolved branch after ${i} poll(s)"
+              exit 0
+            fi
+            echo "waiting for preview branch (${i}) status=${STATUS:-none}"
+            sleep 15
+          done
+          echo "::error::preview branch never became available for $GIT_BRANCH"
+          exit 1
+
+      - name: Install deps (root + astro)
+        run: |
+          bun install --frozen-lockfile
+          (cd astro && bun install --frozen-lockfile)
+
+      - name: Build frontend (astro -> astro/dist)
+        run: bun run build:ui
+
+      # `versions upload` publishes a preview version with its own preview URL
+      # and does NOT roll out to the production route. --var overrides the
+      # branch connection for this version only (plaintext, ephemeral branch).
+      - name: Upload Worker preview bound to the branch DB
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            versions upload
+            --var SUPABASE_URL:${{ steps.branch.outputs.url }}
+            --var SUPABASE_SECRET_KEY:${{ steps.branch.outputs.key }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,13 +1,21 @@
 name: Preview (PR branch)
 
-# Per-PR preview: Supabase's GitHub integration auto-creates a preview BRANCH
-# database from the PR (isolated Postgres, its own ref + keys). Cloudflare has
-# no equivalent auto-wiring, so this workflow reads the branch's connection
-# details and uploads a Worker *preview version* bound to that branch DB -
-# without touching the deployed paste.erfi.io.
+# Per-PR preview: provision an isolated Supabase preview BRANCH database
+# (its own ref + keys), then `wrangler versions upload` a Worker *preview
+# version* bound to that branch DB - without touching deployed paste.erfi.io.
+#
+# We provision the branch OURSELVES via the Management API instead of relying
+# on the GitHub integration's auto-branching. Reason: config.toml pushes custom
+# auth config (SMTP sender_name + email rate limit + GitHub OAuth) that resolves
+# `env()` secrets. Those secrets do not exist on a preview branch, so the deploy
+# 401s ("Custom SMTP required ... Missing SMTP_PASS fields") and Supabase reports
+# the whole deploy as MIGRATIONS_FAILED - even though no migration is at fault.
+# Creating the branch with an explicit `secrets` payload fixes it deterministically.
 #
 # Requires repo secrets: SUPABASE_ACCESS_TOKEN, CLOUDFLARE_API_TOKEN,
-# CLOUDFLARE_ACCOUNT_ID; and repo variable SUPABASE_PROJECT_REF.
+# CLOUDFLARE_ACCOUNT_ID, RESEND_API_KEY, GH_OAUTH_CLIENT_ID,
+# GH_OAUTH_CLIENT_SECRET; and repo variable SUPABASE_PROJECT_REF.
+# Branch teardown on PR close lives in preview-teardown.yml.
 
 on:
   pull_request:
@@ -39,42 +47,82 @@ jobs:
         with:
           version: latest
 
-      - name: Resolve the auto-created Supabase preview branch
+      - name: Provision (or reuse) the Supabase preview branch
         id: branch
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
           GIT_BRANCH: ${{ github.head_ref }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          GH_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+          GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
         run: |
-          # The Supabase GitHub integration creates the branch on PR open.
-          # Resolve it by ID from `branches list` (name-based `branches get`
-          # is version-fragile and returned empty in CI), poll until the
-          # branch reaches a healthy status, then read its connection creds.
-          BID=""
+          set -euo pipefail
+          API="https://api.supabase.com/v1"
+
+          find_row() {
+            curl -fsSL -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+              "$API/projects/$PROJECT_REF/branches" \
+              | jq -r --arg b "$GIT_BRANCH" '.[]|select(.git_branch==$b)|.id+" "+.status'
+          }
+
+          row="$(find_row || true)"
+          BID="$(echo "$row" | awk '{print $1}')"
+          STATUS="$(echo "$row" | awk '{print $2}')"
+
+          # A failed/stale branch can't be cleanly re-migrated - delete + recreate.
+          if [ -n "$BID" ] && { [ "$STATUS" = "MIGRATIONS_FAILED" ] || [ "$STATUS" = "FUNCTIONS_FAILED" ]; }; then
+            echo "existing branch $BID is $STATUS - deleting"
+            curl -fsSL -X DELETE -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" "$API/branches/$BID" >/dev/null || true
+            BID=""; sleep 5
+          fi
+
+          if [ -z "$BID" ]; then
+            body="$(jq -n \
+              --arg gb "$GIT_BRANCH" \
+              --arg r "$RESEND_API_KEY" \
+              --arg ci "$GH_OAUTH_CLIENT_ID" \
+              --arg cs "$GH_OAUTH_CLIENT_SECRET" \
+              '{branch_name:$gb, git_branch:$gb, secrets:{RESEND_API_KEY:$r, GH_OAUTH_CLIENT_ID:$ci, GH_OAUTH_CLIENT_SECRET:$cs}}')"
+            resp="$(curl -sS -X POST -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+              -H "Content-Type: application/json" -d "$body" "$API/projects/$PROJECT_REF/branches")"
+            BID="$(echo "$resp" | jq -r '.id // empty')"
+            if [ -z "$BID" ]; then
+              # Possible race with a concurrent create - re-look-up before failing.
+              echo "create returned no id: $resp"
+              BID="$(find_row | awk '{print $1}')"
+            fi
+            [ -n "$BID" ] || { echo "::error::could not create preview branch for $GIT_BRANCH"; exit 1; }
+            echo "created branch $BID"
+          else
+            echo "reusing branch $BID ($STATUS)"
+          fi
+
+          # Poll to a terminal state; fail fast on failure. (~90s typical.)
+          STATUS=""
           for i in $(seq 1 40); do
-            LIST=$(supabase branches list --project-ref "$PROJECT_REF" --output json 2>/dev/null || echo '[]')
-            ROW=$(echo "$LIST" | jq -c --arg b "$GIT_BRANCH" '.[]|select(.git_branch==$b)' 2>/dev/null)
-            BID=$(echo "$ROW" | jq -r '.id // empty')
-            STATUS=$(echo "$ROW" | jq -r '.status // empty')
+            STATUS="$(curl -fsSL -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+              "$API/projects/$PROJECT_REF/branches" | jq -r --arg b "$BID" '.[]|select(.id==$b)|.status')"
             case "$STATUS" in
-              ACTIVE_HEALTHY|MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED)
-                echo "branch $BID healthy ($STATUS) after ${i} poll(s)"
-                break ;;
-              MIGRATIONS_FAILED|FUNCTIONS_FAILED)
-                echo "::error::preview branch $BID failed provisioning: $STATUS"
-                exit 1 ;;
-              *)
-                echo "waiting for preview branch (${i}) status=${STATUS:-not-created-yet}"
-                BID=""; sleep 15 ;;
+              MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED) echo "branch healthy ($STATUS) after $i poll(s)"; break ;;
+              MIGRATIONS_FAILED|FUNCTIONS_FAILED) echo "::error::preview branch $BID failed: $STATUS"; exit 1 ;;
+              *) echo "waiting ($i) status=${STATUS:-not-created-yet}"; sleep 15 ;;
             esac
           done
-          if [ -z "$BID" ]; then
-            echo "::error::preview branch never became healthy for $GIT_BRANCH"
-            exit 1
-          fi
-          JSON=$(supabase branches get "$BID" --output json)
-          echo "url=$(echo "$JSON" | jq -r '.SUPABASE_URL')" >> "$GITHUB_OUTPUT"
-          echo "key=$(echo "$JSON" | jq -r '.SUPABASE_SERVICE_ROLE_KEY')" >> "$GITHUB_OUTPUT"
+          case "$STATUS" in
+            MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED) : ;;
+            *) echo "::error::preview branch $BID never became healthy (last=$STATUS)"; exit 1 ;;
+          esac
+
+          JSON="$(supabase branches get "$BID" --output json)"
+          URL="$(echo "$JSON" | jq -r '.SUPABASE_URL')"
+          KEY="$(echo "$JSON" | jq -r '.SUPABASE_SERVICE_ROLE_KEY')"
+          echo "::add-mask::$KEY"
+          {
+            echo "url=$URL"
+            echo "key=$KEY"
+            echo "bid=$BID"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install deps (root + astro)
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,10 +43,6 @@ jobs:
         with:
           bun-version: latest
 
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
       - name: Provision (or reuse) the Supabase preview branch
         id: branch
         env:
@@ -114,9 +110,15 @@ jobs:
             *) echo "::error::preview branch $BID never became healthy (last=$STATUS)"; exit 1 ;;
           esac
 
-          JSON="$(supabase branches get "$BID" --output json)"
-          URL="$(echo "$JSON" | jq -r '.SUPABASE_URL')"
-          KEY="$(echo "$JSON" | jq -r '.SUPABASE_SERVICE_ROLE_KEY')"
+          # Read the branch's creds via the Management API (no `supabase link`
+          # needed - the runner checkout is not a linked project). URL is
+          # derived from the branch ref; prefer the new sb_secret key, fall
+          # back to the legacy service_role JWT.
+          BREF="$(curl -fsSL -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" "$API/branches/$BID" | jq -r '.ref')"
+          URL="https://$BREF.supabase.co"
+          KEYS="$(curl -fsSL -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" "$API/projects/$BREF/api-keys?reveal=true")"
+          KEY="$(echo "$KEYS" | jq -r '[.[]|select(.type=="secret")|.api_key][0] // [.[]|select(.name=="service_role")|.api_key][0]')"
+          [ -n "$URL" ] && [ "$KEY" != "null" ] && [ -n "$KEY" ] || { echo "::error::could not read branch creds (ref=$BREF)"; exit 1; }
           echo "::add-mask::$KEY"
           {
             echo "url=$URL"

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ playwright-report/
 # Claude Design reference material — design-system extraction + Iosevka
 # font dump (1.1 GB). Not part of the production artefact; consult locally.
 ui-overhaul/
+bench/.dev.vars

--- a/bench/worker.ts
+++ b/bench/worker.ts
@@ -1,0 +1,112 @@
+/// <reference types="@cloudflare/workers-types" />
+//
+// Isolated A/B benchmark: Supabase read latency from a CF Worker via
+//   A) PostgREST over HTTPS  (the path Pasteriser uses today)
+//   B) Cloudflare Hyperdrive -> Postgres direct connection (pg driver)
+//
+// Runs ONLY on the hyperdrive-bench branch, via `wrangler dev --remote`.
+// Not wired into src/index.ts. Throwaway.
+import { Client } from "pg";
+
+interface Env {
+	HYPERDRIVE: Hyperdrive;
+	SUPABASE_URL: string;
+	SUPABASE_ANON_KEY: string;
+}
+
+// Deterministic read against a throwaway 25-row / ~50KB table. Deterministic
+// (no now()/volatile fn) so Hyperdrive will CACHE it - lets us measure
+// cache-miss vs cache-hit. Mirrors a "list recent rows" read shape.
+const COLS = "id,body";
+const SQL = `select ${COLS} from hd_bench order by id limit $1`;
+
+function stats(xs: number[]) {
+	const s = [...xs].sort((a, b) => a - b);
+	const at = (p: number) => s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))];
+	const sum = s.reduce((a, b) => a + b, 0);
+	return {
+		n: s.length,
+		min: +s[0].toFixed(1),
+		median: +at(50).toFixed(1),
+		p95: +at(95).toFixed(1),
+		max: +s[s.length - 1].toFixed(1),
+		mean: +(sum / s.length).toFixed(1),
+	};
+}
+
+async function timeRest(env: Env, n: number, limit: number) {
+	const url = `${env.SUPABASE_URL}/rest/v1/hd_bench?select=${COLS}&order=id&limit=${limit}`;
+	const times: number[] = [];
+	let rows = 0;
+	for (let i = 0; i < n; i++) {
+		const t = performance.now();
+		const res = await fetch(url, {
+			headers: { apikey: env.SUPABASE_ANON_KEY, authorization: `Bearer ${env.SUPABASE_ANON_KEY}` },
+		});
+		const body = (await res.json()) as unknown[];
+		times.push(performance.now() - t);
+		rows = body.length;
+	}
+	return { ...stats(times), rows };
+}
+
+// Hyperdrive: connect a fresh client per request (the documented pattern -
+// Hyperdrive keeps the real pool warm, so connect() is cheap), then run the
+// same SELECT. Hyperdrive caches read queries by default, so we report the
+// first (cache-miss) call separately from the warm (cache-hit) run.
+async function timeHyperdrive(env: Env, n: number, limit: number, nocache: boolean) {
+	const times: number[] = [];
+	let firstCall = 0;
+	let rows = 0;
+	for (let i = 0; i < n; i++) {
+		const client = new Client({ connectionString: env.HYPERDRIVE.connectionString });
+		// A volatile function (now()) makes the query non-cacheable in Hyperdrive,
+		// so this measures the pooled-but-UNCACHED path (every call hits Postgres).
+		const sql = nocache
+			? `select ${COLS} from hd_bench where now() is not null order by id limit $1`
+			: SQL;
+		const t = performance.now();
+		await client.connect();
+		const r = await client.query(sql, [limit]);
+		const dt = performance.now() - t;
+		if (i === 0) firstCall = dt;
+		else times.push(dt);
+		rows = r.rows.length;
+		env_ctx_waitClose(client);
+	}
+	return { firstCallMs: +firstCall.toFixed(1), warm: stats(times), rows };
+}
+
+// close without blocking the response
+function env_ctx_waitClose(client: Client) {
+	client.end().catch(() => {});
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const u = new URL(request.url);
+		if (u.pathname !== "/bench") {
+			return new Response("GET /bench?n=30&limit=10", { status: 404 });
+		}
+		const n = Math.min(200, Math.max(2, Number(u.searchParams.get("n") ?? 30)));
+		const limit = Math.min(25, Math.max(1, Number(u.searchParams.get("limit") ?? 25)));
+
+		// Warm both paths once (DNS/TLS/pool warmup) before measuring.
+		try {
+			const rest = await timeRest(env, n, limit);
+			const hdCached = await timeHyperdrive(env, n, limit, false);
+			const hdUncached = await timeHyperdrive(env, n, limit, true);
+			return Response.json({
+				query: "25 rows / ~50KB",
+				n,
+				limit,
+				restHttps: rest,
+				hyperdriveCached: hdCached,
+				hyperdriveUncached: hdUncached,
+				note: "times in ms, measured from the Worker on CF edge (wrangler dev --remote). Hyperdrive.warm excludes the first cache-miss call.",
+			});
+		} catch (e: any) {
+			return Response.json({ error: String(e?.message ?? e), stack: e?.stack }, { status: 500 });
+		}
+	},
+};

--- a/bench/worker.ts
+++ b/bench/worker.ts
@@ -1,110 +1,191 @@
 /// <reference types="@cloudflare/workers-types" />
 //
-// Isolated A/B benchmark: Supabase read latency from a CF Worker via
-//   A) PostgREST over HTTPS  (the path Pasteriser uses today)
-//   B) Cloudflare Hyperdrive -> Postgres direct connection (pg driver)
-//
-// Runs ONLY on the hyperdrive-bench branch, via `wrangler dev --remote`.
-// Not wired into src/index.ts. Throwaway.
+// Full CF <-> Supabase integration harness (hyperdrive-bench branch only).
+// Standalone module Worker, NOT wired into src/index.ts. Run with:
+//   wrangler dev --remote --config bench/wrangler.jsonc --port 8799
+// Endpoints: /reads /writes /auth /all
 import { Client } from "pg";
+import postgres from "postgres";
+import { createRemoteJWKSet, jwtVerify, decodeProtectedHeader } from "jose";
 
 interface Env {
 	HYPERDRIVE: Hyperdrive;
 	SUPABASE_URL: string;
 	SUPABASE_ANON_KEY: string;
+	SUPABASE_SERVICE_KEY: string;
+	PG_TXN: string;
+	PG_SESSION: string;
+	TEST_JWT: string;
 }
 
-// Deterministic read against a throwaway 25-row / ~50KB table. Deterministic
-// (no now()/volatile fn) so Hyperdrive will CACHE it - lets us measure
-// cache-miss vs cache-hit. Mirrors a "list recent rows" read shape.
 const COLS = "id,body";
-const SQL = `select ${COLS} from hd_bench order by id limit $1`;
+const READ_SQL = `select ${COLS} from hd_bench order by id limit $1`;
+const READ_SQL_NOCACHE = `select ${COLS} from hd_bench where now() is not null order by id limit $1`;
 
 function stats(xs: number[]) {
+	if (!xs.length) return { n: 0 };
 	const s = [...xs].sort((a, b) => a - b);
 	const at = (p: number) => s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))];
-	const sum = s.reduce((a, b) => a + b, 0);
 	return {
 		n: s.length,
 		min: +s[0].toFixed(1),
 		median: +at(50).toFixed(1),
 		p95: +at(95).toFixed(1),
-		max: +s[s.length - 1].toFixed(1),
-		mean: +(sum / s.length).toFixed(1),
+		mean: +(s.reduce((a, b) => a + b, 0) / s.length).toFixed(1),
 	};
 }
 
-async function timeRest(env: Env, n: number, limit: number) {
-	const url = `${env.SUPABASE_URL}/rest/v1/hd_bench?select=${COLS}&order=id&limit=${limit}`;
+async function timeIt(n: number, fn: () => Promise<number>) {
 	const times: number[] = [];
-	let rows = 0;
+	let first = 0;
 	for (let i = 0; i < n; i++) {
-		const t = performance.now();
-		const res = await fetch(url, {
+		const dt = await fn();
+		if (i === 0) first = +dt.toFixed(1);
+		else times.push(dt);
+	}
+	return { firstCallMs: first, warm: stats(times) };
+}
+
+// --- one pg query, fresh client each call ---
+async function pgOnce(connectionString: string, sql: string, params: any[], ssl = false) {
+	const client = new Client(ssl ? { connectionString, ssl: { rejectUnauthorized: false } } : { connectionString });
+	const t = performance.now();
+	await client.connect();
+	const r = await client.query(sql, params);
+	const dt = performance.now() - t;
+	client.end().catch(() => {});
+	return { dt, rows: r.rows.length };
+}
+
+async function restRead(env: Env) {
+	const url = `${env.SUPABASE_URL}/rest/v1/hd_bench?select=${COLS}&order=id&limit=25`;
+	const t = performance.now();
+	const res = await fetch(url, { headers: { apikey: env.SUPABASE_ANON_KEY, authorization: `Bearer ${env.SUPABASE_ANON_KEY}` } });
+	await res.json();
+	return performance.now() - t;
+}
+
+// Cache API in front of REST: synthetic cache key, 60s TTL.
+async function cacheApiRead(env: Env) {
+	const cache = (caches as any).default as Cache;
+	const key = new Request("https://bench.local/hd_bench_25");
+	const t = performance.now();
+	let res = await cache.match(key);
+	if (!res) {
+		const upstream = await fetch(`${env.SUPABASE_URL}/rest/v1/hd_bench?select=${COLS}&order=id&limit=25`, {
 			headers: { apikey: env.SUPABASE_ANON_KEY, authorization: `Bearer ${env.SUPABASE_ANON_KEY}` },
 		});
-		const body = (await res.json()) as unknown[];
-		times.push(performance.now() - t);
-		rows = body.length;
+		res = new Response(await upstream.text(), { headers: { "content-type": "application/json", "cache-control": "max-age=60" } });
+		await cache.put(key, res.clone());
 	}
-	return { ...stats(times), rows };
+	await res.text();
+	return performance.now() - t;
 }
 
-// Hyperdrive: connect a fresh client per request (the documented pattern -
-// Hyperdrive keeps the real pool warm, so connect() is cheap), then run the
-// same SELECT. Hyperdrive caches read queries by default, so we report the
-// first (cache-miss) call separately from the warm (cache-hit) run.
-async function timeHyperdrive(env: Env, n: number, limit: number, nocache: boolean) {
-	const times: number[] = [];
-	let firstCall = 0;
-	let rows = 0;
-	for (let i = 0; i < n; i++) {
-		const client = new Client({ connectionString: env.HYPERDRIVE.connectionString });
-		// A volatile function (now()) makes the query non-cacheable in Hyperdrive,
-		// so this measures the pooled-but-UNCACHED path (every call hits Postgres).
-		const sql = nocache
-			? `select ${COLS} from hd_bench where now() is not null order by id limit $1`
-			: SQL;
+async function reads(env: Env, n: number) {
+	const out: Record<string, unknown> = {};
+	out.restHttps = await timeIt(n, restRead.bind(null, env));
+	out.cacheApi = await timeIt(n, cacheApiRead.bind(null, env));
+	out.hyperdriveCached = await timeIt(n, async () => (await pgOnce(env.HYPERDRIVE.connectionString, READ_SQL, [25])).dt);
+	out.hyperdriveUncached = await timeIt(n, async () => (await pgOnce(env.HYPERDRIVE.connectionString, READ_SQL_NOCACHE, [25])).dt);
+	// raw driver straight to Supavisor (no Hyperdrive)
+	// Raw drivers straight to Supavisor from the Worker runtime - single probe
+	// each, 6s timeout so a hang fails fast instead of blowing the request.
+	const withTimeout = <T>(p: Promise<T>, ms: number) =>
+		Promise.race([p, new Promise<never>((_, rej) => setTimeout(() => rej(new Error(`timeout after ${ms}ms (connection hung)`)), ms))]);
+	try {
+		const r = await withTimeout(pgOnce(env.PG_TXN, READ_SQL, [25], true), 6000);
+		out.supavisorTxn_nodePg = { ok: true, ms: +r.dt.toFixed(1) };
+	} catch (e: any) {
+		out.supavisorTxn_nodePg = { ok: false, error: String(e?.message ?? e) };
+	}
+	try {
+		const r = await withTimeout(
+			(async () => {
+				const sql = postgres(env.PG_TXN, { ssl: "require", prepare: false, fetch_types: false, max: 1, idle_timeout: 2, connect_timeout: 5 });
+				const t = performance.now();
+				await sql`select id, body from hd_bench order by id limit 25`;
+				const dt = performance.now() - t;
+				sql.end({ timeout: 1 }).catch(() => {});
+				return dt;
+			})(),
+			6000,
+		);
+		out.supavisorTxn_postgresJs = { ok: true, ms: +r.toFixed(1) };
+	} catch (e: any) {
+		out.supavisorTxn_postgresJs = { ok: false, error: String(e?.message ?? e) };
+	}
+	return out;
+}
+
+async function writes(env: Env, n: number) {
+	const out: Record<string, unknown> = {};
+	out.restInsert = await timeIt(n, async () => {
 		const t = performance.now();
-		await client.connect();
-		const r = await client.query(sql, [limit]);
-		const dt = performance.now() - t;
-		if (i === 0) firstCall = dt;
-		else times.push(dt);
-		rows = r.rows.length;
-		env_ctx_waitClose(client);
+		const res = await fetch(`${env.SUPABASE_URL}/rest/v1/bench_kv`, {
+			method: "POST",
+			headers: { apikey: env.SUPABASE_SERVICE_KEY, authorization: `Bearer ${env.SUPABASE_SERVICE_KEY}`, "content-type": "application/json", prefer: "return=minimal" },
+			body: JSON.stringify({ v: "rest" }),
+		});
+		await res.text();
+		return performance.now() - t;
+	});
+	out.hyperdriveInsert = await timeIt(n, async () => (await pgOnce(env.HYPERDRIVE.connectionString, "insert into bench_kv (v) values ($1)", ["hd"])).dt);
+	try {
+		out.supavisorTxnInsert = await timeIt(n, async () => (await pgOnce(env.PG_TXN, "insert into bench_kv (v) values ($1)", ["txn"], true)).dt);
+	} catch (e: any) {
+		out.supavisorTxnInsert = { error: String(e?.message ?? e) };
 	}
-	return { firstCallMs: +firstCall.toFixed(1), warm: stats(times), rows };
+	return out;
 }
 
-// close without blocking the response
-function env_ctx_waitClose(client: Client) {
-	client.end().catch(() => {});
+async function auth(env: Env, n: number) {
+	const jwks = createRemoteJWKSet(new URL(`${env.SUPABASE_URL}/auth/v1/.well-known/jwks.json`));
+	const out: Record<string, unknown> = {};
+	// A. verify JWT locally at the edge (JWKS cached after first fetch)
+	let claims: any = null;
+	out.localVerify = await timeIt(n, async () => {
+		const t = performance.now();
+		const { payload } = await jwtVerify(env.TEST_JWT, jwks, { audience: "authenticated" });
+		claims = { sub: payload.sub, role: (payload as any).role, exp: payload.exp };
+		return performance.now() - t;
+	});
+	out.verifiedClaims = claims;
+	out.header = decodeProtectedHeader(env.TEST_JWT);
+	// B. getUser round-trip to Supabase (revocation-aware)
+	out.getUserRoundtrip = await timeIt(n, async () => {
+		const t = performance.now();
+		const res = await fetch(`${env.SUPABASE_URL}/auth/v1/user`, { headers: { apikey: env.SUPABASE_ANON_KEY, authorization: `Bearer ${env.TEST_JWT}` } });
+		await res.json();
+		return performance.now() - t;
+	});
+	// C. tampered token must be rejected
+	try {
+		await jwtVerify(env.TEST_JWT.slice(0, -3) + "AAA", jwks, { audience: "authenticated" });
+		out.tamperedRejected = false;
+	} catch {
+		out.tamperedRejected = true;
+	}
+	return out;
 }
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		const u = new URL(request.url);
-		if (u.pathname !== "/bench") {
-			return new Response("GET /bench?n=30&limit=10", { status: 404 });
-		}
-		const n = Math.min(200, Math.max(2, Number(u.searchParams.get("n") ?? 30)));
-		const limit = Math.min(25, Math.max(1, Number(u.searchParams.get("limit") ?? 25)));
-
-		// Warm both paths once (DNS/TLS/pool warmup) before measuring.
+		const n = Math.min(100, Math.max(2, Number(u.searchParams.get("n") ?? 30)));
 		try {
-			const rest = await timeRest(env, n, limit);
-			const hdCached = await timeHyperdrive(env, n, limit, false);
-			const hdUncached = await timeHyperdrive(env, n, limit, true);
-			return Response.json({
-				query: "25 rows / ~50KB",
-				n,
-				limit,
-				restHttps: rest,
-				hyperdriveCached: hdCached,
-				hyperdriveUncached: hdUncached,
-				note: "times in ms, measured from the Worker on CF edge (wrangler dev --remote). Hyperdrive.warm excludes the first cache-miss call.",
-			});
+			switch (u.pathname) {
+				case "/reads":
+					return Response.json({ region: "eu-central-1", n, reads: await reads(env, n) });
+				case "/writes":
+					return Response.json({ n, writes: await writes(env, n) });
+				case "/auth":
+					return Response.json({ n, auth: await auth(env, n) });
+				case "/all":
+					return Response.json({ region: "eu-central-1", n, reads: await reads(env, n), writes: await writes(env, Math.min(n, 20)), auth: await auth(env, n) });
+				default:
+					return new Response("GET /reads | /writes | /auth | /all  (?n=30)", { status: 404 });
+			}
 		} catch (e: any) {
 			return Response.json({ error: String(e?.message ?? e), stack: e?.stack }, { status: 500 });
 		}

--- a/bench/wrangler.jsonc
+++ b/bench/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+	"$schema": "../node_modules/wrangler/config-schema.json",
+	"name": "pasteriser-hyperdrive-bench",
+	"main": "worker.ts",
+	"account_id": "25f21f141824546aa72c74451a11b419",
+	"compatibility_date": "2026-07-12",
+	"compatibility_flags": ["nodejs_compat"],
+	"vars": {
+		"SUPABASE_URL": "https://dewddkcmwrzbpynylyhg.supabase.co"
+	},
+	// SUPABASE_ANON_KEY comes from bench/.dev.vars (gitignored) for `wrangler dev`.
+	"hyperdrive": [
+		{ "binding": "HYPERDRIVE", "id": "977d7826add048b594ddd9c394db943c" }
+	]
+}

--- a/bench/wrangler.jsonc
+++ b/bench/wrangler.jsonc
@@ -10,6 +10,6 @@
 	},
 	// SUPABASE_ANON_KEY comes from bench/.dev.vars (gitignored) for `wrangler dev`.
 	"hyperdrive": [
-		{ "binding": "HYPERDRIVE", "id": "977d7826add048b594ddd9c394db943c" }
+		{ "binding": "HYPERDRIVE", "id": "<hyperdrive-config-id>" }
 	]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/check": "^0.9.2",
         "@supabase/supabase-js": "^2.103.0",
         "hono": "^4.12.8",
+        "pg": ">=8.16.3",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -17,6 +18,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.2.1",
+        "@types/pg": "^8.20.0",
         "@typescript-eslint/eslint-plugin": "^8.54.0",
         "@typescript-eslint/parser": "^8.54.0",
         "concurrently": "^9.1.2",
@@ -337,6 +339,8 @@
 
     "@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
 
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.62.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.62.0", "@typescript-eslint/type-utils": "8.62.0", "@typescript-eslint/utils": "8.62.0", "@typescript-eslint/visitor-keys": "8.62.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.62.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.62.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.62.0", "@typescript-eslint/types": "8.62.0", "@typescript-eslint/typescript-estree": "8.62.0", "@typescript-eslint/visitor-keys": "8.62.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA=="],
@@ -623,6 +627,22 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -632,6 +652,14 @@
     "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -686,6 +714,8 @@
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -808,6 +838,8 @@
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,9 @@
         "@astrojs/check": "^0.9.2",
         "@supabase/supabase-js": "^2.103.0",
         "hono": "^4.12.8",
+        "jose": "^6.2.3",
         "pg": ">=8.16.3",
+        "postgres": "^3.4.9",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -553,6 +555,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
@@ -652,6 +656,8 @@
     "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
 		"@astrojs/check": "^0.9.2",
 		"@supabase/supabase-js": "^2.103.0",
 		"hono": "^4.12.8",
+		"jose": "^6.2.3",
 		"pg": ">=8.16.3",
+		"postgres": "^3.4.9",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"@astrojs/check": "^0.9.2",
 		"@supabase/supabase-js": "^2.103.0",
 		"hono": "^4.12.8",
+		"pg": ">=8.16.3",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
@@ -45,6 +46,7 @@
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/node": "^25.2.1",
+		"@types/pg": "^8.20.0",
 		"@typescript-eslint/eslint-plugin": "^8.54.0",
 		"@typescript-eslint/parser": "^8.54.0",
 		"concurrently": "^9.1.2",

--- a/supabase/migrations/20260714090000_preview_branch_smoke.sql
+++ b/supabase/migrations/20260714090000_preview_branch_smoke.sql
@@ -1,5 +1,7 @@
 -- Preview-branch trigger for the CF preview workflow (hyperdrive-bench).
--- Intentional no-op: exercises the Supabase GitHub integration's
+-- Intentional no-op: satisfies the Supabase GitHub integration's
 -- "Supabase changes only" auto-branching without altering any schema.
--- Safe if merged - changes nothing in production.
-select 1;
+-- Uses a DO block (returns NO result set) - a bare `select 1;` produces a
+-- result set that the branch migration runner rejects even though psql
+-- accepts it. Safe if merged - changes nothing.
+do $$ begin perform 1; end $$;

--- a/supabase/migrations/20260714090000_preview_branch_smoke.sql
+++ b/supabase/migrations/20260714090000_preview_branch_smoke.sql
@@ -1,0 +1,5 @@
+-- Preview-branch trigger for the CF preview workflow (hyperdrive-bench).
+-- Intentional no-op: exercises the Supabase GitHub integration's
+-- "Supabase changes only" auto-branching without altering any schema.
+-- Safe if merged - changes nothing in production.
+select 1;


### PR DESCRIPTION
Exercises the full Cloudflare<->Supabase integration surface and wires per-PR preview branches into a Worker preview.

- `bench/`: standalone integration harness (not wired into the app) - REST vs Hyperdrive vs Cache API vs raw driver, writes, auth. See commits for measured numbers.
- `.github/workflows/preview.yml`: reads the auto-created Supabase preview branch and `wrangler versions upload`s a Worker preview bound to it.
- no-op migration: triggers the Supabase GitHub integration's auto-branching ("Supabase changes only").

This PR is a live test of the preview pipeline; not intended to merge to prod as-is.